### PR TITLE
don't drop reco1 data products in early stages of wire-cell reco2 workflow

### DIFF
--- a/ubreco/WcpPortedReco/ProducePort/job/run_slimmed_port_data_sp.fcl
+++ b/ubreco/WcpPortedReco/ProducePort/job/run_slimmed_port_data_sp.fcl
@@ -69,7 +69,7 @@ microboone_tfile_metadata:
 }
 
 source.inputCommands: [
-		        "keep *_*_*_*",
+		        "keep *_*_*_*"
 			#"drop sim::SimEnergyDeposits_largeant_*_*",
 			#"drop sim::SimChannels_largeant_*_*",
 			#"drop sim::AuxDetSimChannel_*_*_*",

--- a/ubreco/WcpPortedReco/ProducePort/job/run_slimmed_port_data_sp.fcl
+++ b/ubreco/WcpPortedReco/ProducePort/job/run_slimmed_port_data_sp.fcl
@@ -70,17 +70,17 @@ microboone_tfile_metadata:
 
 source.inputCommands: [
 		        "keep *_*_*_*",
-			"drop sim::SimEnergyDeposits_largeant_*_*",
-			"drop sim::SimChannels_largeant_*_*",
-			"drop sim::AuxDetSimChannel_*_*_*",
-			"drop raw::OpDetWaveform_pmtreadoutnonoise_*_OverlayDetsim",
-			"drop crt::CRTSimData_crtdetsim_*_OverlayDetsim",
-			"drop crt::CRTHit_*_*_OverlayDetsim",
-			"drop *_*_mixer_DataOverlay",
-			"drop *_threshold_nfspl1_OverlayStage1a",
-			"drop recob::Wires_*nfspl1_*_*",
-			"drop recob::OpFlash_*_*_OverlayStage1a",
-			"drop recob::OpHit_*_*_OverlayStage1a"
+			#"drop sim::SimEnergyDeposits_largeant_*_*",
+			#"drop sim::SimChannels_largeant_*_*",
+			#"drop sim::AuxDetSimChannel_*_*_*",
+			#"drop raw::OpDetWaveform_pmtreadoutnonoise_*_OverlayDetsim",
+			#"drop crt::CRTSimData_crtdetsim_*_OverlayDetsim",
+			#"drop crt::CRTHit_*_*_OverlayDetsim",
+			#"drop *_*_mixer_DataOverlay",
+			#"drop *_threshold_nfspl1_OverlayStage1a",
+			#"drop recob::Wires_*nfspl1_*_*",
+			#"drop recob::OpFlash_*_*_OverlayStage1a",
+			#"drop recob::OpHit_*_*_OverlayStage1a"
 		      ]
 
 services.SpaceCharge.CalibrationInputFilename: "SpaceCharge/SCEoffsets_dataDriven_combined_bkwd_Jan18.root"


### PR DESCRIPTION
This PR modifies run_slimmed_port_data_sp.fcl to not drop reco1 products from artroot files. This is necessary to produce larcv images needed for LANTERN and LANTERN/Wire-Cell integration efforts (as both the data products that this fcl previously dropped and some that it produces are needed to generate larcv images.)

This change won't affect the wire-cell reco2 workflow in any way, as these data products are dropped later on in the workflow anyway. Wire-cell experts confirmed that this change is fine.