### PR TITLE
Pandora: Quit early if there is an existing vertex list.

### DIFF
--- a/ubreco/MicroBooNEPandora/scripts/PandoraSettings_Neutrino_MicroBooNE_DL.xml
+++ b/ubreco/MicroBooNEPandora/scripts/PandoraSettings_Neutrino_MicroBooNE_DL.xml
@@ -398,7 +398,7 @@
     <!-- Output list management -->
     <algorithm type = "LArPostProcessing">
         <PfoListNames>NeutrinoParticles3D TrackParticles3D ShowerParticles3D CandidateVertexParticles3D</PfoListNames>
-        <VertexListNames>NeutrinoVertices3D DaughterVertices3D CandidateVertices3D CandidateVerticesCopy3D</VertexListNames>
+        <VertexListNames>NeutrinoVertices3D DaughterVertices3D CandidateVertices3D CandidateVerticesCopy3D NeutrinoVertices3D_Pass1</VertexListNames>
         <ClusterListNames>ClustersU ClustersV ClustersW TrackClusters3D ShowerClusters3D</ClusterListNames>
         <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D</CaloHitListNames>
         <CurrentPfoListReplacement>NeutrinoParticles3D</CurrentPfoListReplacement>

--- a/ubreco/MicroBooNEPandora/scripts/PandoraSettings_Neutrino_MicroBooNE_DL.xml
+++ b/ubreco/MicroBooNEPandora/scripts/PandoraSettings_Neutrino_MicroBooNE_DL.xml
@@ -121,6 +121,7 @@
     <algorithm type = "LArSvmVertexSelection">
         <InputCaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</InputCaloHitListNames>
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
+        <InputVertexListName>CandidateVertices3D</InputVertexListName>
         <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
         <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
         <MvaFileName>PandoraSvm_v03_11_00.xml</MvaFileName>


### PR DESCRIPTION
This change should make Pandora's old vertexing stop earlier, skipping some un-needed work and potential for breaking an event, if a vertex has already been defined by the DLVertexing.

This works locally, but I'll test on a GPVM tomorrow morning.