### PR TITLE
Adding Wire-Cell PMT Info

### DIFF
--- a/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
+++ b/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
@@ -19,6 +19,7 @@
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "ubobj/WcpPort/NuSelectionBDT.h"
 #include "ubobj/WcpPort/NuSelectionKINE.h"
+#include "ubobj/WcpPort/WCPMTInfo.h"
 
 #include <memory>
 #include <string>
@@ -94,7 +95,7 @@ nsm::WireCellPF::WireCellPF(fhicl::ParameterSet const& p)
 
   MF_LOG_DEBUG("WireCellPF") << "Debug: WireCellPF() begins";
   if(f_PFport) produces< std::vector<simb::MCParticle> >();
-  if(f_PFport) produces< std::vector<nsm::NuSelectionBDT::WCPMTInfo> >("WCPMTInfo");
+  if(f_PFport) produces< std::vector<nsm::WCPMTInfo> >("WCPMTInfo");
   if(f_BDTport) produces< std::vector<nsm::NuSelectionBDT> >();
   if(f_KINEport) produces< std::vector<nsm::NuSelectionKINE> >();
   MF_LOG_DEBUG("WireCellPF") << "Debug: WireCellPF() ends";
@@ -124,7 +125,7 @@ void nsm::WireCellPF::produce(art::Event& e)
 
 if(f_PFport){
   auto outputPF = std::make_unique< std::vector<simb::MCParticle> >();
-  auto outputWCPMTInfo = std::make_unique< std::vector<nsm::NuSelectionBDT::WCPMTInfo> >();
+  auto outputWCPMTInfo = std::make_unique< std::vector<nsm::WCPMTInfo> >();
   if(badinput){
 	e.put(std::move(outputPF));
     std::cout << "badinput, not loading from T_match tree\n";
@@ -233,7 +234,7 @@ if(f_PFport){
     }
     
     // Create WCPMTInfo struct and populate it
-    nsm::NuSelectionBDT::WCPMTInfo wcpmtinfo;
+    nsm::WCPMTInfo wcpmtinfo;
     wcpmtinfo.WCPMTInfoPePred = vec_WCPMTInfo_pe_pred;
     wcpmtinfo.WCPMTInfoPeMeas = vec_WCPMTInfo_pe_meas;
     wcpmtinfo.WCPMTInfoPeMeasErr = vec_WCPMTInfo_pe_meas_err;
@@ -751,20 +752,6 @@ if(f_BDTport){
   float ssm_kine_pio_phi_2 = 0.;
   float ssm_kine_pio_dis_2 = 0.;
   float ssm_kine_pio_angle = 0.;
-
-  std::vector<double> *WCPMTInfoPePred= new std::vector<double>;
-  std::vector<double> *WCPMTInfoPeMeas= new std::vector<double>;
-  std::vector<double> *WCPMTInfoPeMeasErr= new std::vector<double>;
-  int WCPMTInfoTPCClusterID = -1;
-  int WCPMTInfoFlashID = -1;
-  double WCPMTInfoStrength = -1.;
-  int WCPMTInfoEventType = -1;
-  double WCPMTInfoKSDistance = -1.;
-  double WCPMTInfoChi2 = -1.;
-  int WCPMTInfoNDF = -1;
-  double WCPMTInfoClusterLength = -1.;
-  int WCPMTInfoNeutrinoType = -1;
-  double WCPMTInfoFlashTime = -1.;
 
   if(f_ssmBDT){
 
@@ -4228,22 +4215,6 @@ if(f_BDTport){
 	  nue_score
   };
 
-  nsm::NuSelectionBDT::WCPMTInfo _WCPMTInfo_init = {
-    WCPMTInfoPePred,
-    WCPMTInfoPeMeas,
-    WCPMTInfoPeMeasErr,
-    WCPMTInfoTPCClusterID,
-    WCPMTInfoFlashID,
-    WCPMTInfoStrength,
-    WCPMTInfoEventType,
-    WCPMTInfoKSDistance,
-    WCPMTInfoChi2,
-    WCPMTInfoNDF,
-    WCPMTInfoClusterLength,
-    WCPMTInfoNeutrinoType,
-    WCPMTInfoFlashTime
-  };
-
   std::cout<<"T_tagger size: "<<tree3->GetEntries()<<std::endl;
   if(tree3->GetEntries()==0){ std::cout<<"Empty T_tagger"<<std::endl;}
   else{
@@ -4295,7 +4266,6 @@ if(f_BDTport){
       nsmbdt.SetMajorCosmicTagger(_MajorCosmicTagger_init);
       nsmbdt.SetNumuCCTagger(_NumuCCTagger_init);
       nsmbdt.SetBDTscores(_BDTscores_init);
-      nsmbdt.SetWCPMTInfo(_WCPMTInfo_init);
     }
 
     outputBDTvars->push_back(nsmbdt);

--- a/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
+++ b/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
@@ -94,21 +94,9 @@ nsm::WireCellPF::WireCellPF(fhicl::ParameterSet const& p)
 
   MF_LOG_DEBUG("WireCellPF") << "Debug: WireCellPF() begins";
   if(f_PFport) produces< std::vector<simb::MCParticle> >();
+  if(f_PFport) produces< std::vector<nsm::NuSelectionBDT::WCPMTInfo> >("WCPMTInfo");
   if(f_BDTport) produces< std::vector<nsm::NuSelectionBDT> >();
   if(f_KINEport) produces< std::vector<nsm::NuSelectionKINE> >();
-  if (f_PFport) produces< std::vector<double> >("WCPMTInfoPePred");
-  if (f_PFport) produces< std::vector<double> >("WCPMTInfoPeMeas");
-  if (f_PFport) produces< std::vector<double> >("WCPMTInfoPeMeasErr");
-  if (f_PFport) produces< int >("WCPMTInfoTPCClusterID");
-  if (f_PFport) produces< int >("WCPMTInfoFlashID");
-  if (f_PFport) produces< double >("WCPMTInfoStrength");
-  if (f_PFport) produces< int >("WCPMTInfoEventType");
-  if (f_PFport) produces< double >("WCPMTInfoKSDistance");
-  if (f_PFport) produces< double >("WCPMTInfoChi2");
-  if (f_PFport) produces< int >("WCPMTInfoNDF");
-  if (f_PFport) produces< double >("WCPMTInfoClusterLength");
-  if (f_PFport) produces< int >("WCPMTInfoNeutrinoType");
-  if (f_PFport) produces< double >("WCPMTInfoFlashTime");
   MF_LOG_DEBUG("WireCellPF") << "Debug: WireCellPF() ends";
 
 }
@@ -136,23 +124,12 @@ void nsm::WireCellPF::produce(art::Event& e)
 
 if(f_PFport){
   auto outputPF = std::make_unique< std::vector<simb::MCParticle> >();
+  auto outputWCPMTInfo = std::make_unique< std::vector<nsm::NuSelectionBDT::WCPMTInfo> >();
   if(badinput){
 	e.put(std::move(outputPF));
     std::cout << "badinput, not loading from T_match tree\n";
-    // Put empty products for all WCPMTInfo* products when input is bad
-    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPePred");
-    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeas");
-    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeasErr");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoTPCClusterID");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoFlashID");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoStrength");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoEventType");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoKSDistance");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoChi2");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoNDF");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoClusterLength");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoNeutrinoType");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoFlashTime");
+    // Put empty WCPMTInfo product when input is bad
+    e.put(std::move(outputWCPMTInfo), "WCPMTInfo");
 	//return;
   }
   else{
@@ -165,19 +142,19 @@ if(f_PFport){
 
   std::cout << "preparing to read T_match tree\n";
 
-  Int_t tpc_cluster_id;
-  Int_t flash_id;
-  Double_t strength;
-  Double_t pe_pred[32];
-  Double_t pe_meas[32];
-  Double_t pe_meas_err[32];
-  Int_t event_type;
-  Double_t ks_dis;
-  Double_t chi2;
-  Int_t ndf;
-  Double_t cluster_length;
+  Int_t WCPMTInfo_tpc_cluster_id;
+  Int_t WCPMTInfo_flash_id;
+  Double_t WCPMTInfo_strength;
+  Double_t WCPMTInfo_pe_pred[32];
+  Double_t WCPMTInfo_pe_meas[32];
+  Double_t WCPMTInfo_pe_meas_err[32];
+  Int_t WCPMTInfo_event_type;
+  Double_t WCPMTInfo_ks_dis;
+  Double_t WCPMTInfo_chi2;
+  Int_t WCPMTInfo_ndf;
+  Double_t WCPMTInfo_cluster_length;
   Int_t neutrino_type;
-  Double_t flash_time;
+  Double_t WCPMTInfo_flash_time;
   
   TTree *tree2 = (TTree*)fin->Get(fInput_tree2.c_str());
   if(tree2) {
@@ -185,43 +162,43 @@ if(f_PFport){
     tree2->SetBranchStatus("*", 0);
 
     tree2->SetBranchStatus("tpc_cluster_id", 1);
-    tree2->SetBranchAddress("tpc_cluster_id",&tpc_cluster_id);
+    tree2->SetBranchAddress("tpc_cluster_id",&WCPMTInfo_tpc_cluster_id);
 
     tree2->SetBranchStatus("flash_id", 1);
-    tree2->SetBranchAddress("flash_id",&flash_id);
+    tree2->SetBranchAddress("flash_id",&WCPMTInfo_flash_id);
 
     tree2->SetBranchStatus("strength", 1);
-    tree2->SetBranchAddress("strength",&strength);
+    tree2->SetBranchAddress("strength",&WCPMTInfo_strength);
 
     tree2->SetBranchStatus("pe_pred", 1);
-    tree2->SetBranchAddress("pe_pred",&pe_pred);
+    tree2->SetBranchAddress("pe_pred",&WCPMTInfo_pe_pred);
 
     tree2->SetBranchStatus("pe_meas", 1);
-    tree2->SetBranchAddress("pe_meas",&pe_meas);
+    tree2->SetBranchAddress("pe_meas",&WCPMTInfo_pe_meas);
 
     tree2->SetBranchStatus("pe_meas_err", 1);
-    tree2->SetBranchAddress("pe_meas_err",&pe_meas_err);
+    tree2->SetBranchAddress("pe_meas_err",&WCPMTInfo_pe_meas_err);
 
     tree2->SetBranchStatus("event_type", 1);
-    tree2->SetBranchAddress("event_type",&event_type);
+    tree2->SetBranchAddress("event_type",&WCPMTInfo_event_type);
 
     tree2->SetBranchStatus("ks_dis", 1);
-    tree2->SetBranchAddress("ks_dis",&ks_dis);
+    tree2->SetBranchAddress("ks_dis",&WCPMTInfo_ks_dis);
 
     tree2->SetBranchStatus("chi2", 1);
-    tree2->SetBranchAddress("chi2",&chi2);
+    tree2->SetBranchAddress("chi2",&WCPMTInfo_chi2);
 
     tree2->SetBranchStatus("ndf", 1);
-    tree2->SetBranchAddress("ndf",&ndf);
+    tree2->SetBranchAddress("ndf",&WCPMTInfo_ndf);
 
     tree2->SetBranchStatus("cluster_length", 1);
-    tree2->SetBranchAddress("cluster_length",&cluster_length);
+    tree2->SetBranchAddress("cluster_length",&WCPMTInfo_cluster_length);
 
     tree2->SetBranchStatus("neutrino_type", 1);
     tree2->SetBranchAddress("neutrino_type",&neutrino_type);
 
     tree2->SetBranchStatus("flash_time", 1);
-    tree2->SetBranchAddress("flash_time",&flash_time);
+    tree2->SetBranchAddress("flash_time",&WCPMTInfo_flash_time);
 
     for(int i=0; i<tree2->GetEntries(); i++){
       tree2->GetEntry(i);
@@ -231,59 +208,52 @@ if(f_PFport){
 
     std::cout << "T_match/pe_meas[32] values: ";
     for(int i=0; i<32; i++){
-      std::cout << pe_meas[i] << " ";
+      std::cout << WCPMTInfo_pe_meas[i] << " ";
     }
     std::cout << "\n";
 
     std::cout << "T_match/pe_pred[32] values: ";
     for(int i=0; i<32; i++){
-      std::cout << pe_pred[i] << " ";
+      std::cout << WCPMTInfo_pe_pred[i] << " ";
     }
     std::cout << "\n";
 
     // put pred_pe and meas_pe into the resulting file with e.put(std::move( ))
     
     // Create vectors for pe_pred and pe_meas data
-    auto output_pe_pred = std::make_unique< std::vector<double> >();
-    auto output_pe_meas = std::make_unique< std::vector<double> >();
-    auto output_pe_meas_err = std::make_unique< std::vector<double> >();
+    std::vector<double> *vec_WCPMTInfo_pe_pred = new std::vector<double>();
+    std::vector<double> *vec_WCPMTInfo_pe_meas = new std::vector<double>();
+    std::vector<double> *vec_WCPMTInfo_pe_meas_err = new std::vector<double>();
 
     // Copy the arrays to vectors
     for(int i=0; i<32; i++){
-      output_pe_pred->push_back(pe_pred[i]);
-      output_pe_meas->push_back(pe_meas[i]);
-      output_pe_meas_err->push_back(pe_meas_err[i]);
+      vec_WCPMTInfo_pe_pred->push_back(WCPMTInfo_pe_pred[i]);
+      vec_WCPMTInfo_pe_meas->push_back(WCPMTInfo_pe_meas[i]);
+      vec_WCPMTInfo_pe_meas_err->push_back(WCPMTInfo_pe_meas_err[i]);
     }
     
-    e.put(std::move(output_pe_pred), "WCPMTInfoPePred");
-    e.put(std::move(output_pe_meas), "WCPMTInfoPeMeas");
-    e.put(std::move(output_pe_meas_err), "WCPMTInfoPeMeasErr");
-    e.put(std::make_unique<int>(tpc_cluster_id), "WCPMTInfoTPCClusterID");
-    e.put(std::make_unique<int>(flash_id), "WCPMTInfoFlashID");
-    e.put(std::make_unique<double>(strength), "WCPMTInfoStrength");
-    e.put(std::make_unique<int>(event_type), "WCPMTInfoEventType");
-    e.put(std::make_unique<double>(ks_dis), "WCPMTInfoKSDistance");
-    e.put(std::make_unique<double>(chi2), "WCPMTInfoChi2");
-    e.put(std::make_unique<int>(ndf), "WCPMTInfoNDF");
-    e.put(std::make_unique<double>(cluster_length), "WCPMTInfoClusterLength");
-    e.put(std::make_unique<int>(neutrino_type), "WCPMTInfoNeutrinoType");
-    e.put(std::make_unique<double>(flash_time), "WCPMTInfoFlashTime");
+    // Create WCPMTInfo struct and populate it
+    nsm::NuSelectionBDT::WCPMTInfo wcpmtinfo;
+    wcpmtinfo.WCPMTInfoPePred = vec_WCPMTInfo_pe_pred;
+    wcpmtinfo.WCPMTInfoPeMeas = vec_WCPMTInfo_pe_meas;
+    wcpmtinfo.WCPMTInfoPeMeasErr = vec_WCPMTInfo_pe_meas_err;
+    wcpmtinfo.WCPMTInfoTPCClusterID = WCPMTInfo_tpc_cluster_id;
+    wcpmtinfo.WCPMTInfoFlashID = WCPMTInfo_flash_id;
+    wcpmtinfo.WCPMTInfoStrength = WCPMTInfo_strength;
+    wcpmtinfo.WCPMTInfoEventType = WCPMTInfo_event_type;
+    wcpmtinfo.WCPMTInfoKSDistance = WCPMTInfo_ks_dis;
+    wcpmtinfo.WCPMTInfoChi2 = WCPMTInfo_chi2;
+    wcpmtinfo.WCPMTInfoNDF = WCPMTInfo_ndf;
+    wcpmtinfo.WCPMTInfoClusterLength = WCPMTInfo_cluster_length;
+    wcpmtinfo.WCPMTInfoNeutrinoType = neutrino_type;
+    wcpmtinfo.WCPMTInfoFlashTime = WCPMTInfo_flash_time;
+    
+    outputWCPMTInfo->push_back(wcpmtinfo);
+    e.put(std::move(outputWCPMTInfo), "WCPMTInfo");
 
   } else {
     std::cout << "T_match tree not found, filling with defaults\n";
-    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPePred");
-    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeas");
-    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeasErr");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoTPCClusterID");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoFlashID");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoStrength");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoEventType");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoKSDistance");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoChi2");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoNDF");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoClusterLength");
-    e.put(std::make_unique<int>(-1), "WCPMTInfoNeutrinoType");
-    e.put(std::make_unique<double>(-1.0), "WCPMTInfoFlashTime");
+    e.put(std::move(outputWCPMTInfo), "WCPMTInfo");
   }
 
   TTree *tree = (TTree*)fin->Get(fInput_tree.c_str());
@@ -781,6 +751,20 @@ if(f_BDTport){
   float ssm_kine_pio_phi_2 = 0.;
   float ssm_kine_pio_dis_2 = 0.;
   float ssm_kine_pio_angle = 0.;
+
+  std::vector<double> *WCPMTInfoPePred= new std::vector<double>;
+  std::vector<double> *WCPMTInfoPeMeas= new std::vector<double>;
+  std::vector<double> *WCPMTInfoPeMeasErr= new std::vector<double>;
+  int WCPMTInfoTPCClusterID = -1;
+  int WCPMTInfoFlashID = -1;
+  double WCPMTInfoStrength = -1.;
+  int WCPMTInfoEventType = -1;
+  double WCPMTInfoKSDistance = -1.;
+  double WCPMTInfoChi2 = -1.;
+  int WCPMTInfoNDF = -1;
+  double WCPMTInfoClusterLength = -1.;
+  int WCPMTInfoNeutrinoType = -1;
+  double WCPMTInfoFlashTime = -1.;
 
   if(f_ssmBDT){
 
@@ -2877,6 +2861,7 @@ if(f_BDTport){
 	  float tro_4_score;
 	  float tro_5_score;
 	  float nue_score;
+
 	  tree3->SetBranchAddress("cosmict_2_4_score",&cosmict_2_4_score);
 	  tree3->SetBranchAddress("cosmict_3_5_score",&cosmict_3_5_score);
 	  tree3->SetBranchAddress("cosmict_6_score",&cosmict_6_score);
@@ -2919,8 +2904,6 @@ if(f_BDTport){
 	  tree3->SetBranchAddress("tro_4_score",&tro_4_score);
 	  tree3->SetBranchAddress("tro_5_score",&tro_5_score);
 	  tree3->SetBranchAddress("nue_score",&nue_score);
-
-
 
   /// Read and assign values
   tree3->GetEntry(0); // rare case: multiple in-beam matched activity
@@ -4245,6 +4228,22 @@ if(f_BDTport){
 	  nue_score
   };
 
+  nsm::NuSelectionBDT::WCPMTInfo _WCPMTInfo_init = {
+    WCPMTInfoPePred,
+    WCPMTInfoPeMeas,
+    WCPMTInfoPeMeasErr,
+    WCPMTInfoTPCClusterID,
+    WCPMTInfoFlashID,
+    WCPMTInfoStrength,
+    WCPMTInfoEventType,
+    WCPMTInfoKSDistance,
+    WCPMTInfoChi2,
+    WCPMTInfoNDF,
+    WCPMTInfoClusterLength,
+    WCPMTInfoNeutrinoType,
+    WCPMTInfoFlashTime
+  };
+
   std::cout<<"T_tagger size: "<<tree3->GetEntries()<<std::endl;
   if(tree3->GetEntries()==0){ std::cout<<"Empty T_tagger"<<std::endl;}
   else{
@@ -4296,6 +4295,7 @@ if(f_BDTport){
       nsmbdt.SetMajorCosmicTagger(_MajorCosmicTagger_init);
       nsmbdt.SetNumuCCTagger(_NumuCCTagger_init);
       nsmbdt.SetBDTscores(_BDTscores_init);
+      nsmbdt.SetWCPMTInfo(_WCPMTInfo_init);
     }
 
     outputBDTvars->push_back(nsmbdt);

--- a/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
+++ b/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
@@ -96,6 +96,19 @@ nsm::WireCellPF::WireCellPF(fhicl::ParameterSet const& p)
   if(f_PFport) produces< std::vector<simb::MCParticle> >();
   if(f_BDTport) produces< std::vector<nsm::NuSelectionBDT> >();
   if(f_KINEport) produces< std::vector<nsm::NuSelectionKINE> >();
+  if (f_PFport) produces< std::vector<double> >("NewPMTInfoPePred");
+  if (f_PFport) produces< std::vector<double> >("NewPMTInfoPeMeas");
+  if (f_PFport) produces< std::vector<double> >("NewPMTInfoPeMeasErr");
+  if (f_PFport) produces< int >("NewPMTInfoTPCClusterID");
+  if (f_PFport) produces< int >("NewPMTInfoFlashID");
+  if (f_PFport) produces< double >("NewPMTInfoStrength");
+  if (f_PFport) produces< int >("NewPMTInfoEventType");
+  if (f_PFport) produces< double >("NewPMTInfoKSDistance");
+  if (f_PFport) produces< double >("NewPMTInfoChi2");
+  if (f_PFport) produces< int >("NewPMTInfoNDF");
+  if (f_PFport) produces< double >("NewPMTInfoClusterLength");
+  if (f_PFport) produces< int >("NewPMTInfoNeutrinoType");
+  if (f_PFport) produces< double >("NewPMTInfoFlashTime");
   MF_LOG_DEBUG("WireCellPF") << "Debug: WireCellPF() ends";
 
 }
@@ -128,6 +141,20 @@ if(f_PFport){
   if(badinput){
 	e.put(std::move(outputPF));
     std::cout << "badinput, not loading from T_match tree\n";
+    // Put empty products for all NewPMTInfo* products when input is bad
+    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPePred");
+    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeas");
+    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeasErr");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoTPCClusterID");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoFlashID");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoStrength");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoEventType");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoKSDistance");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoChi2");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoNDF");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoClusterLength");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoNeutrinoType");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoFlashTime");
 	//return;
   }
   else{
@@ -216,6 +243,49 @@ if(f_PFport){
     }
     std::cout << "\n";
 
+    // put pred_pe and meas_pe into the resulting file with e.put(std::move( ))
+    
+    // Create vectors for pe_pred and pe_meas data
+    auto output_pe_pred = std::make_unique< std::vector<double> >();
+    auto output_pe_meas = std::make_unique< std::vector<double> >();
+    auto output_pe_meas_err = std::make_unique< std::vector<double> >();
+
+    // Copy the arrays to vectors
+    for(int i=0; i<32; i++){
+      output_pe_pred->push_back(pe_pred[i]);
+      output_pe_meas->push_back(pe_meas[i]);
+      output_pe_meas_err->push_back(pe_meas_err[i]);
+    }
+    
+    e.put(std::move(output_pe_pred), "NewPMTInfoPePred");
+    e.put(std::move(output_pe_meas), "NewPMTInfoPeMeas");
+    e.put(std::move(output_pe_meas_err), "NewPMTInfoPeMeasErr");
+    e.put(std::make_unique<int>(tpc_cluster_id), "NewPMTInfoTPCClusterID");
+    e.put(std::make_unique<int>(flash_id), "NewPMTInfoFlashID");
+    e.put(std::make_unique<double>(strength), "NewPMTInfoStrength");
+    e.put(std::make_unique<int>(event_type), "NewPMTInfoEventType");
+    e.put(std::make_unique<double>(ks_dis), "NewPMTInfoKSDistance");
+    e.put(std::make_unique<double>(chi2), "NewPMTInfoChi2");
+    e.put(std::make_unique<int>(ndf), "NewPMTInfoNDF");
+    e.put(std::make_unique<double>(cluster_length), "NewPMTInfoClusterLength");
+    e.put(std::make_unique<int>(neutrino_type), "NewPMTInfoNeutrinoType");
+    e.put(std::make_unique<double>(flash_time), "NewPMTInfoFlashTime");
+
+  } else {
+    std::cout << "T_match tree not found, filling with defaults\n";
+    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPePred");
+    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeas");
+    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeasErr");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoTPCClusterID");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoFlashID");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoStrength");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoEventType");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoKSDistance");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoChi2");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoNDF");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoClusterLength");
+    e.put(std::make_unique<int>(-1), "NewPMTInfoNeutrinoType");
+    e.put(std::make_unique<double>(-1.0), "NewPMTInfoFlashTime");
   }
 
   TTree *tree = (TTree*)fin->Get(fInput_tree.c_str());

--- a/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
+++ b/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
@@ -96,19 +96,19 @@ nsm::WireCellPF::WireCellPF(fhicl::ParameterSet const& p)
   if(f_PFport) produces< std::vector<simb::MCParticle> >();
   if(f_BDTport) produces< std::vector<nsm::NuSelectionBDT> >();
   if(f_KINEport) produces< std::vector<nsm::NuSelectionKINE> >();
-  if (f_PFport) produces< std::vector<double> >("NewPMTInfoPePred");
-  if (f_PFport) produces< std::vector<double> >("NewPMTInfoPeMeas");
-  if (f_PFport) produces< std::vector<double> >("NewPMTInfoPeMeasErr");
-  if (f_PFport) produces< int >("NewPMTInfoTPCClusterID");
-  if (f_PFport) produces< int >("NewPMTInfoFlashID");
-  if (f_PFport) produces< double >("NewPMTInfoStrength");
-  if (f_PFport) produces< int >("NewPMTInfoEventType");
-  if (f_PFport) produces< double >("NewPMTInfoKSDistance");
-  if (f_PFport) produces< double >("NewPMTInfoChi2");
-  if (f_PFport) produces< int >("NewPMTInfoNDF");
-  if (f_PFport) produces< double >("NewPMTInfoClusterLength");
-  if (f_PFport) produces< int >("NewPMTInfoNeutrinoType");
-  if (f_PFport) produces< double >("NewPMTInfoFlashTime");
+  if (f_PFport) produces< std::vector<double> >("WCPMTInfoPePred");
+  if (f_PFport) produces< std::vector<double> >("WCPMTInfoPeMeas");
+  if (f_PFport) produces< std::vector<double> >("WCPMTInfoPeMeasErr");
+  if (f_PFport) produces< int >("WCPMTInfoTPCClusterID");
+  if (f_PFport) produces< int >("WCPMTInfoFlashID");
+  if (f_PFport) produces< double >("WCPMTInfoStrength");
+  if (f_PFport) produces< int >("WCPMTInfoEventType");
+  if (f_PFport) produces< double >("WCPMTInfoKSDistance");
+  if (f_PFport) produces< double >("WCPMTInfoChi2");
+  if (f_PFport) produces< int >("WCPMTInfoNDF");
+  if (f_PFport) produces< double >("WCPMTInfoClusterLength");
+  if (f_PFport) produces< int >("WCPMTInfoNeutrinoType");
+  if (f_PFport) produces< double >("WCPMTInfoFlashTime");
   MF_LOG_DEBUG("WireCellPF") << "Debug: WireCellPF() ends";
 
 }
@@ -141,20 +141,20 @@ if(f_PFport){
   if(badinput){
 	e.put(std::move(outputPF));
     std::cout << "badinput, not loading from T_match tree\n";
-    // Put empty products for all NewPMTInfo* products when input is bad
-    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPePred");
-    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeas");
-    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeasErr");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoTPCClusterID");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoFlashID");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoStrength");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoEventType");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoKSDistance");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoChi2");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoNDF");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoClusterLength");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoNeutrinoType");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoFlashTime");
+    // Put empty products for all WCPMTInfo* products when input is bad
+    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPePred");
+    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeas");
+    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeasErr");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoTPCClusterID");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoFlashID");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoStrength");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoEventType");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoKSDistance");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoChi2");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoNDF");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoClusterLength");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoNeutrinoType");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoFlashTime");
 	//return;
   }
   else{
@@ -257,35 +257,35 @@ if(f_PFport){
       output_pe_meas_err->push_back(pe_meas_err[i]);
     }
     
-    e.put(std::move(output_pe_pred), "NewPMTInfoPePred");
-    e.put(std::move(output_pe_meas), "NewPMTInfoPeMeas");
-    e.put(std::move(output_pe_meas_err), "NewPMTInfoPeMeasErr");
-    e.put(std::make_unique<int>(tpc_cluster_id), "NewPMTInfoTPCClusterID");
-    e.put(std::make_unique<int>(flash_id), "NewPMTInfoFlashID");
-    e.put(std::make_unique<double>(strength), "NewPMTInfoStrength");
-    e.put(std::make_unique<int>(event_type), "NewPMTInfoEventType");
-    e.put(std::make_unique<double>(ks_dis), "NewPMTInfoKSDistance");
-    e.put(std::make_unique<double>(chi2), "NewPMTInfoChi2");
-    e.put(std::make_unique<int>(ndf), "NewPMTInfoNDF");
-    e.put(std::make_unique<double>(cluster_length), "NewPMTInfoClusterLength");
-    e.put(std::make_unique<int>(neutrino_type), "NewPMTInfoNeutrinoType");
-    e.put(std::make_unique<double>(flash_time), "NewPMTInfoFlashTime");
+    e.put(std::move(output_pe_pred), "WCPMTInfoPePred");
+    e.put(std::move(output_pe_meas), "WCPMTInfoPeMeas");
+    e.put(std::move(output_pe_meas_err), "WCPMTInfoPeMeasErr");
+    e.put(std::make_unique<int>(tpc_cluster_id), "WCPMTInfoTPCClusterID");
+    e.put(std::make_unique<int>(flash_id), "WCPMTInfoFlashID");
+    e.put(std::make_unique<double>(strength), "WCPMTInfoStrength");
+    e.put(std::make_unique<int>(event_type), "WCPMTInfoEventType");
+    e.put(std::make_unique<double>(ks_dis), "WCPMTInfoKSDistance");
+    e.put(std::make_unique<double>(chi2), "WCPMTInfoChi2");
+    e.put(std::make_unique<int>(ndf), "WCPMTInfoNDF");
+    e.put(std::make_unique<double>(cluster_length), "WCPMTInfoClusterLength");
+    e.put(std::make_unique<int>(neutrino_type), "WCPMTInfoNeutrinoType");
+    e.put(std::make_unique<double>(flash_time), "WCPMTInfoFlashTime");
 
   } else {
     std::cout << "T_match tree not found, filling with defaults\n";
-    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPePred");
-    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeas");
-    e.put(std::make_unique<std::vector<double>>(), "NewPMTInfoPeMeasErr");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoTPCClusterID");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoFlashID");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoStrength");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoEventType");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoKSDistance");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoChi2");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoNDF");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoClusterLength");
-    e.put(std::make_unique<int>(-1), "NewPMTInfoNeutrinoType");
-    e.put(std::make_unique<double>(-1.0), "NewPMTInfoFlashTime");
+    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPePred");
+    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeas");
+    e.put(std::make_unique<std::vector<double>>(), "WCPMTInfoPeMeasErr");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoTPCClusterID");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoFlashID");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoStrength");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoEventType");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoKSDistance");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoChi2");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoNDF");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoClusterLength");
+    e.put(std::make_unique<int>(-1), "WCPMTInfoNeutrinoType");
+    e.put(std::make_unique<double>(-1.0), "WCPMTInfoFlashTime");
   }
 
   TTree *tree = (TTree*)fin->Get(fInput_tree.c_str());

--- a/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
+++ b/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
@@ -134,8 +134,6 @@ void nsm::WireCellPF::produce(art::Event& e)
 	}
   }
 
-std::cout << "f_PFport: " << f_PFport << "\n";
-
 if(f_PFport){
   auto outputPF = std::make_unique< std::vector<simb::MCParticle> >();
   if(badinput){

--- a/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
+++ b/ubreco/WcpPortedReco/ProducePort/WireCellPF_module.cc
@@ -121,10 +121,13 @@ void nsm::WireCellPF::produce(art::Event& e)
 	}
   }
 
+std::cout << "f_PFport: " << f_PFport << "\n";
+
 if(f_PFport){
   auto outputPF = std::make_unique< std::vector<simb::MCParticle> >();
   if(badinput){
 	e.put(std::move(outputPF));
+    std::cout << "badinput, not loading from T_match tree\n";
 	//return;
   }
   else{
@@ -134,16 +137,85 @@ if(f_PFport){
   // 4th bit: NC
   // 5th bit: long muon
   // 6th bit: nue CC
-  Int_t neutrino_type = 0;
+
+  std::cout << "preparing to read T_match tree\n";
+
+  Int_t tpc_cluster_id;
+  Int_t flash_id;
+  Double_t strength;
+  Double_t pe_pred[32];
+  Double_t pe_meas[32];
+  Double_t pe_meas_err[32];
+  Int_t event_type;
+  Double_t ks_dis;
+  Double_t chi2;
+  Int_t ndf;
+  Double_t cluster_length;
+  Int_t neutrino_type;
+  Double_t flash_time;
+  
   TTree *tree2 = (TTree*)fin->Get(fInput_tree2.c_str());
   if(tree2) {
-  tree2->SetBranchStatus("*", 0);
-  tree2->SetBranchStatus("neutrino_type", 1);
-  tree2->SetBranchAddress("neutrino_type",&neutrino_type);
+    std::cout << "in WireCellPF, tree2 containing T_match found\n";
+    tree2->SetBranchStatus("*", 0);
+
+    tree2->SetBranchStatus("tpc_cluster_id", 1);
+    tree2->SetBranchAddress("tpc_cluster_id",&tpc_cluster_id);
+
+    tree2->SetBranchStatus("flash_id", 1);
+    tree2->SetBranchAddress("flash_id",&flash_id);
+
+    tree2->SetBranchStatus("strength", 1);
+    tree2->SetBranchAddress("strength",&strength);
+
+    tree2->SetBranchStatus("pe_pred", 1);
+    tree2->SetBranchAddress("pe_pred",&pe_pred);
+
+    tree2->SetBranchStatus("pe_meas", 1);
+    tree2->SetBranchAddress("pe_meas",&pe_meas);
+
+    tree2->SetBranchStatus("pe_meas_err", 1);
+    tree2->SetBranchAddress("pe_meas_err",&pe_meas_err);
+
+    tree2->SetBranchStatus("event_type", 1);
+    tree2->SetBranchAddress("event_type",&event_type);
+
+    tree2->SetBranchStatus("ks_dis", 1);
+    tree2->SetBranchAddress("ks_dis",&ks_dis);
+
+    tree2->SetBranchStatus("chi2", 1);
+    tree2->SetBranchAddress("chi2",&chi2);
+
+    tree2->SetBranchStatus("ndf", 1);
+    tree2->SetBranchAddress("ndf",&ndf);
+
+    tree2->SetBranchStatus("cluster_length", 1);
+    tree2->SetBranchAddress("cluster_length",&cluster_length);
+
+    tree2->SetBranchStatus("neutrino_type", 1);
+    tree2->SetBranchAddress("neutrino_type",&neutrino_type);
+
+    tree2->SetBranchStatus("flash_time", 1);
+    tree2->SetBranchAddress("flash_time",&flash_time);
+
     for(int i=0; i<tree2->GetEntries(); i++){
-	tree2->GetEntry(i);
-	if(neutrino_type>1) break; // this should be the in-beam flash match
+      tree2->GetEntry(i);
+      if(neutrino_type>1) break; // this should be the in-beam flash match
     }
+    std::cout << "Should be in-beam flash match, neutrino_type: " << neutrino_type << "\n";
+
+    std::cout << "T_match/pe_meas[32] values: ";
+    for(int i=0; i<32; i++){
+      std::cout << pe_meas[i] << " ";
+    }
+    std::cout << "\n";
+
+    std::cout << "T_match/pe_pred[32] values: ";
+    for(int i=0; i<32; i++){
+      std::cout << pe_pred[i] << " ";
+    }
+    std::cout << "\n";
+
   }
 
   TTree *tree = (TTree*)fin->Get(fInput_tree.c_str());


### PR DESCRIPTION
This PR saves a very small amount of information related to Wire-Cell light flash reconstruction. In particular, this saves the predicted and measured PE counts on each PMT that are used for flash matching (32x2 numbers, plus some other related information about the matching flash). This information could be useful to try to identify out-TPC activity relevant for single photon searches, among other things.

This has been tested locally and on the grid.

This accompanies these PRs: https://github.com/uboone/ubana/pull/57, https://github.com/uboone/ubobj/pull/4