### PR TITLE
Update pandora hit creation interface

### DIFF
--- a/ubreco/MicroBooNEPandora/MicroBooNEPandora_module.cc
+++ b/ubreco/MicroBooNEPandora/MicroBooNEPandora_module.cc
@@ -388,7 +388,9 @@ void MicroBooNEPandora::ReprocessSlices(const art::Event &evt, const SliceVector
             }
         }
 
-        LArPandoraInput::CreatePandoraHits2D(evt, m_inputSettings, m_driftVolumeMap, artHits, idToHitMap);
+        HitToScores hitToScores;
+        HitToScoreLabels hitToScoreLabels;
+        LArPandoraInput::CreatePandoraHits2D(evt, m_inputSettings, m_driftVolumeMap, artHits, hitToScores, hitToScoreLabels, idToHitMap);
         m_inputSettings.m_hitCounterOffset += artHits.size();
 
         if (m_enableMCParticles && !evt.isRealData())


### PR DESCRIPTION
This PR updates the interface to CreatePandoraHits2D to support changes implemented for ICARUS, as per the dependency [larpandora PR 51](https://github.com/LArSoft/larpandora/pull/51). These new variables are unused in this use case, so no product changes are expected.