### PR TITLE
Feature/pandora metrics fix

### DIFF
--- a/ubreco/MicroBooNEPandora/MicroBooNEPandora_module.cc
+++ b/ubreco/MicroBooNEPandora/MicroBooNEPandora_module.cc
@@ -198,10 +198,9 @@ MicroBooNEPandora::~MicroBooNEPandora()
 
 void MicroBooNEPandora::produce(art::Event &evt)
 {
-
     if (!m_processExistingSlices)
-
     {
+        this->SetPandoraEventInformation(evt);
         IdToHitMap idToHitMap;
         this->CreatePandoraInput(evt, idToHitMap);
         this->RunPandoraInstances();

--- a/ubreco/MicroBooNEPandora/MicroBooNEPandora_module.cc
+++ b/ubreco/MicroBooNEPandora/MicroBooNEPandora_module.cc
@@ -357,6 +357,7 @@ void MicroBooNEPandora::ReprocessSlices(const art::Event &evt, const SliceVector
         RawMCParticleVector generatorArtMCParticleVector;
         MCTruthToMCParticles artMCTruthToMCParticles;
         MCParticlesToMCTruth artMCParticlesToMCTruth;
+        TrackIDToEDepSims artTrackIDToEDepSims;
 
         bool areSimChannelsValid(false);
 
@@ -395,7 +396,7 @@ void MicroBooNEPandora::ReprocessSlices(const art::Event &evt, const SliceVector
 
         if (m_enableMCParticles && !evt.isRealData())
         {
-            LArPandoraInput::CreatePandoraMCParticles(m_inputSettings, artMCTruthToMCParticles, artMCParticlesToMCTruth, generatorArtMCParticleVector);
+            LArPandoraInput::CreatePandoraMCParticles(m_inputSettings, artMCTruthToMCParticles, artMCParticlesToMCTruth, generatorArtMCParticleVector, artTrackIDToEDepSims);
             LArPandoraInput::CreatePandoraMCLinks2D(m_inputSettings, idToHitMap, artHitsToTrackIDEs);
         }
 


### PR DESCRIPTION
Hello,

This PR fixes the following run time issue:

MasterAlgorithm: Exception during initialization of worker instances STATUS_CODE_NOT_INITIALIZED
this->InitializeWorkerInstances() return STATUS_CODE_NOT_INITIALIZED
    in function: Run
    in file:     /exp/uboone/app/users/greenlee/testrel/srcs/ubreco/ubreco/MicroBooNEPandora/MicroBooNEMasterAlgorithm.cc line#: 34
iter->second->Run() throw STATUS_CODE_NOT_INITIALIZED
    in function: RunAlgorithm
    in file:     /scratch/workspace/build-larsoft/BUILDTYPE/prof/QUAL/s131-e26/label1/swarm/label2/ALMA9/build/pandora/v05_00_00/build/Linux64bit+3.10-2.17-e26-prof/PandoraSDK-prefix/src/PandoraSDK/src/Api/PandoraContentApiImpl.cc line#: 263
Failure in algorithm Alg0003, MicroBooNEMaster, STATUS_CODE_NOT_INITIALIZED

`this->SetPandoraEventInformation(evt)` initialises and sets the run/subrun/event related pandora instance member variables. Without these initialised, Pandora throws STATUS_CODE_NOT_INITIALIZED. 